### PR TITLE
chore: update actions/checkout to v4.2.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Danger(SwiftLint)
         uses: docker://ghcr.io/danger/danger-swift-with-swiftlint:3.8.0
         env:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to improve the security and stability of our GitHub Actions workflow by updating the `actions/checkout` action to a specific version. This follows the security best practice recommended by GitHub to prevent potential supply chain attacks.

### Detail

This Pull Request changes the version reference in our GitHub Actions workflow from a floating version tag to a specific commit hash:

- Updates `actions/checkout` from `v2` to `v4.2.2` (commit hash: `11bd71901bbe5b1630ceea73d27597364c9af683`)

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] No tests are needed as this is a workflow configuration change.
* [x] No CHANGELOG update needed as this is an internal workflow change.